### PR TITLE
Fix Spanish and French versions of 'guard' section

### DIFF
--- a/content/es.html
+++ b/content/es.html
@@ -851,8 +851,7 @@ end
 Guard es una buena herramienta pero, como es normal, no siempre cubre todas las necesidades. Algunas veces el flujo de trabajo de TDD
 funciona mejor con un atajo de teclado que facilite la ejecución sólo de los ejemplos que se deseen y cuando
 se desee. Después, se puede usar una tarea de rake para ejecutar la suite de pruebas entera antes de subir el código.
-<a href="https://github.com/myronmarston/vim_files/blob/5bd4faad7c020ebcbf62dcbc59985262b4eacb53/vimrc.after#L61-103">Aquí</a>
-el atajo de teclado de vim.
+<a href="https://github.com/myronmarston/vim_files/blob/5bd4faad7c020ebcbf62dcbc59985262b4eacb53/vimrc.after#L61-103">Aquí están</a> unos ejemplos de atajos de teclado de vim.
 </p>
 
 <p>

--- a/content/fr.html
+++ b/content/fr.html
@@ -815,8 +815,7 @@ end
 
 <p>
 Guard est un bon outil mais il ne couvre pas tous les besoins. Quelquefois votre flux TDD travaille mieux avec des raccourcis clavier qui rendent le lancement d'exemple unitaire aisé. Vous pouvez alors utiliser les tâches rake pour lancer la totalité des tests avant de pousser votre code.
-<a href="https://github.com/myronmarston/vim_files/blob/5bd4faad7c020ebcbf62dcbc59985262b4eacb53/vimrc.after#L61-103">ici</a>
-les raccourcis vim.
+<a href="https://github.com/myronmarston/vim_files/blob/5bd4faad7c020ebcbf62dcbc59985262b4eacb53/vimrc.after#L61-103">Voici</a> quelques exemples des raccourcis vim.
 </p>
 
 <p>


### PR DESCRIPTION
The existing sentence about Vim keybindings in the Spanish and French versions of the "Automatic tests with guard" section could best be read as "Here the Vim keybinding". I updated the translation to read "Here are some example Vim keybindings."