### PR TITLE
Add blurb in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+## Contributing
+
+1. Fork it
+2. Create your feature branch from `gh-pages` (`git checkout -b my-new-feature gh-pages`)
+3. Commit your changes (`git commit -m 'Topic: Changes made'`)
+4. Push to the branch (`git push origin my-topic`)
+5. Create new Pull Request


### PR DESCRIPTION
As mention on https://github.com/lelylan/betterspecs/issues/168#issuecomment-188786211
> Add blurb in CONTRIBUTING about choosing the gh-pages branch. Even though it is currently the default, some people may still try to choose master.

I've added this as a separate file. Is it ok for you ?

English is not my native language so feel free to make any comments.