### PR TITLE
Fix grammer on Japanese in `Use let and let!` section

### DIFF
--- a/jp.html
+++ b/jp.html
@@ -549,7 +549,7 @@ Use <code>let!</code> if you want to define the variable when the block is defin
 This can be useful to populate your database to test queries or scopes.
 </p> -->
 <p>
-ブロックが定義した時に変数を定義したい時は<code>let!</code>を使いましょう。
+ブロックが定義された時に変数を定義したい時は<code>let!</code>を使いましょう。
 これはDBのクエリーやスコープのテストで有用です。
 </p>
 


### PR DESCRIPTION
Hello, Thank you for great documentaion on Rspec.

I fix grammer in `Use let and let!` section.
### Reason

Because `when the block is defined.` does not translate in the passive voice.
