### PR TITLE
Fix Kanji conversion

### DIFF
--- a/jp.html
+++ b/jp.html
@@ -826,7 +826,7 @@ In our experience, shared examples are used mainly for controllers. Since models
 different from each other, they (usually) do not share much logic.
 </p> -->
 <p>
-経験によると、shared exampleは対体コントローラで使われます。モデルはお互いかなり異なるため、（普通は）多くのロジックを共有しません。
+経験によると、shared exampleは大体コントローラで使われます。モデルはお互いかなり異なるため、（普通は）多くのロジックを共有しません。
 </p>
 
 <!-- <p>


### PR DESCRIPTION
Fix conversion of Kanji from 対体 to 大体.

### reason
#### Japanese
> 経験によると、shared exampleは__対体__コントローラで使われます。

#### English
> In our experience, shared examples are used __mainly__ for controllers.

In Japanese language, 'meaning' is same meaning as '大体' .