### PR TITLE
Fix typo of japanese translation

### DIFF
--- a/jp.html
+++ b/jp.html
@@ -833,7 +833,7 @@ different from each other, they (usually) do not share much logic.
 Learn more about <a href="https://www.relishapp.com/rspec/rspec-core/v/2-11/docs/example-groups/shared-examples">rspec shared examples</a>.
 </p> -->
 <p>
-<a href="https://www.relishapp.com/rspec/rspec-core/v/2-11/docs/example-groups/shared-examples">rspec shared examples</a>に対してもっと学ぶ。
+<a href="https://www.relishapp.com/rspec/rspec-core/v/2-11/docs/example-groups/shared-examples">rspec shared examples</a>に関してもっと学ぶ。
 </p>
 
 <p>
@@ -1158,7 +1158,7 @@ explaining how to mix them together.
 </p> -->
 <p>
 <a href="https://github.com/bblimke/webmock">webmock</a>と
-<a href="https://github.com/vcr/vcr">VCR</a>に対してもっと学ぶ。
+<a href="https://github.com/vcr/vcr">VCR</a>に関してもっと学ぶ。
 二つを一緒に使う方法を説明した
 <a href="http://marnen.github.com/webmock-presentation/webmock.html">良いプレゼン</a>
 もあります。
@@ -1219,7 +1219,7 @@ end
 Learn more about <a href="http://jeffkreeftmeijer.com/2010/fuubar-the-instafailing-rspec-progress-bar-formatter/">fuubar</a>.
 </p> -->
 <p>
-<a href="http://jeffkreeftmeijer.com/2010/fuubar-the-instafailing-rspec-progress-bar-formatter/">fuubar</a>に対してもっと学ぶ。
+<a href="http://jeffkreeftmeijer.com/2010/fuubar-the-instafailing-rspec-progress-bar-formatter/">fuubar</a>に関してもっと学ぶ。
 </p>
 
 <p>
@@ -1369,4 +1369,4 @@ testing in Ruby.
   allowtransparency="true" frameborder="0" scrolling="0" width="300px" height="30px"></iframe>
 
 </div>
-<a href="https://github.com/guard/guard-rspec">guard-rspec</a>に対してもっと学ぶ。
+<a href="https://github.com/guard/guard-rspec">guard-rspec</a>に関してもっと学ぶ。


### PR DESCRIPTION
In `jp.html`, "More about the ~" is translated as "に対して" in Japanese ,but if it is translated as "に対して", it might be confusing because it is normally translated as "に関して".

It is a subtle change but to make it a little bit easier to understand. 