### PR TITLE
Replace deprecated `before_filter` -> `before_action`

### DIFF
--- a/br.html
+++ b/br.html
@@ -273,8 +273,8 @@ end
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/es.html
+++ b/es.html
@@ -266,8 +266,8 @@ Probar es una buena práctica, pero si no se prueban los casos extremos, no ser�
 <p class="base">Acción de destruir</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/fr.html
+++ b/fr.html
@@ -252,8 +252,8 @@ Tester est une bonne pratique, mais est inutile si vous ne testez pas tous les c
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/index.html
+++ b/index.html
@@ -239,8 +239,8 @@ Testing is a good practice, but if you do not test the edge cases, it will not b
 <p class="spec-title">Destroy Action</p>
 
 {% highlight ruby %}
-before_filter :find_owned_resources
-before_filter :find_resource
+before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/jp.html
+++ b/jp.html
@@ -308,8 +308,8 @@ be useful. Test valid, edge and invalid case. For example, consider the followin
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/ko.html
+++ b/ko.html
@@ -251,8 +251,8 @@ end
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/ru.html
+++ b/ru.html
@@ -272,8 +272,8 @@ end
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -262,8 +262,8 @@ end
 <p class="base">destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -326,8 +326,8 @@ be useful. Test valid, edge and invalid case. For example, consider the followin
 <p class="base">Destroy action</p>
 
 <div>
-<pre><code class="ruby">before_filter :find_owned_resources
-before_filter :find_resource
+<pre><code class="ruby">before_action :find_owned_resources
+before_action :find_resource
 
 def destroy
   render 'show'


### PR DESCRIPTION
[Rails 4.2 prefers](http://edgeguides.rubyonrails.org/4_2_release_notes.html#action-pack-notable-changes) the use of `*_action` over `*_filter`

[Rails 5.0 deprecates](http://edgeguides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations) the use of `*_filter` & it will be removed in 5.1
