### PR TITLE
Improve translation into Japnese of the Ruby documentation convention

### DIFF
--- a/jp.html
+++ b/jp.html
@@ -96,7 +96,7 @@ Be clear about what method you are describing. For instance, use the Ruby docume
 referring to an instance method's name.
 </p> -->
 <p>
-作成中のメソッドを明らかにしましょう。例えば、Ruby文書の規約ではクラスメソッドの名前には<code>.</code>(もしくは<code>::</code>)をインスタンスメソッドの名前には<code>#</code>を使っています。
+作成中のメソッドを明らかにしましょう。例えば、Rubyのコード規約ではクラスメソッドの名前には<code>.</code>(もしくは<code>::</code>)をインスタンスメソッドの名前には<code>#</code>を使っています。
 </p>
 
 <p class="wrong">bad</p>


### PR DESCRIPTION
I improve translation into Japnese of `the Ruby documentation convention`.

### Reason

In general, Japnese say `コード規約` instead of `文章の規約`.
