### PR TITLE
Solves issue #11

### DIFF
--- a/index.html
+++ b/index.html
@@ -551,10 +551,10 @@ If you have ever worked in a medium size project (but also in small ones), test 
 <p class="spec-title spec-correct">good</p>
 
 {% highlight ruby %}
-describe "User" do
+RSpec.describe User do
   describe ".top" do
     before { FactoryGirl.create_list(:user, 3) }
-    it { expect(User.top(2)).to have(2).item }
+    it { expect(described_class.top(2).size).to eq 2 }
   end
 end
 {% endhighlight %}


### PR DESCRIPTION
* Avoid `have` form, as it will be deprecated
* Describe class, not string
* Use `described_class`

See: http://rspec.info/blog/2013/11/rspec-2-99-and-3-0-betas-have-been-released