### PR TITLE
Fix spacing issue in spec examples.

### DIFF
--- a/br.html
+++ b/br.html
@@ -430,7 +430,7 @@ end
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/es.html
+++ b/es.html
@@ -464,7 +464,7 @@ Usa <code>let</code> para inicializar acciones que son "lazy loaded" para probar
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/fr.html
+++ b/fr.html
@@ -450,7 +450,7 @@ Utiliser <code>let</code> pour initialiser des actions longues à charger pour t
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/index.html
+++ b/index.html
@@ -463,7 +463,7 @@ Use <code>let</code> to initialize actions that are lazy loaded to test your spe
 
 {% highlight ruby %}
 context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/jp.html
+++ b/jp.html
@@ -531,7 +531,7 @@ Use <code>let</code> to initialize actions that are lazy loaded to test your spe
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/ko.html
+++ b/ko.html
@@ -465,7 +465,7 @@ end
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/ru.html
+++ b/ru.html
@@ -427,7 +427,7 @@ end
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/zh_cn.html
+++ b/zh_cn.html
@@ -418,7 +418,7 @@ end
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: settings.resource_id, value: 'on'} }
+  let(:properties) { { id: settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties

--- a/zh_tw.html
+++ b/zh_tw.html
@@ -506,7 +506,7 @@ Use <code>let</code> to initialize actions that are lazy loaded to test your spe
 
 <div>
 <pre><code class="ruby">context 'when updates a not existing property value' do
-  let(:properties) { { id: Settings.resource_id, value: 'on'} }
+  let(:properties) { { id: Settings.resource_id, value: 'on' } }
 
   def update
     resource.properties = properties


### PR DESCRIPTION
This pull request fixes an inconsistent spacing issue in the example specs. I noticed this while reading [betterspec.org](http://betterspecs.org/).